### PR TITLE
PUB-2021 - Updated chart version

### DIFF
--- a/charts/pip-cron-trigger/Chart.yaml
+++ b/charts/pip-cron-trigger/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: HMCTS PIP Team
 dependencies:
   - name: job
-    version: 0.7.12
+    version: 1.0.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2021

### Change description ###

Updated version of the chart job to latest version.

Latest version includes a change to concurrency defaulting to false. We only run one of each job at a time, so current as false is OK.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
